### PR TITLE
Create fromParsedJson function to public API

### DIFF
--- a/mapper/lib/src/mapper.dart
+++ b/mapper/lib/src/mapper.dart
@@ -29,6 +29,12 @@ class JsonMapper {
 
   /// Converts JSON String to Dart object instance of type T
   static T? deserialize<T>(String? jsonValue,
+          [DeserializationOptions options = defaultDeserializationOptions]) =>
+      fromParsedJson(
+          jsonValue != null ? _jsonDecoder.convert(jsonValue) : null, options);
+
+  /// Maps an already parsed JSON to Dart object instance of type T
+  static T? fromParsedJson<T>(dynamic object,
       [DeserializationOptions options = defaultDeserializationOptions]) {
     final targetType = T != dynamic
         ? T
@@ -39,7 +45,7 @@ class JsonMapper {
         ? true
         : throw MissingTypeForDeserializationError());
     return instance._deserializeObject(
-        jsonValue != null ? _jsonDecoder.convert(jsonValue) : null,
+        object,
         DeserializationContext(options,
             typeInfo: instance._getTypeInfo(targetType))) as T?;
   }


### PR DESCRIPTION
Create a function to the `JsonMapper` that allows to just map, but not parse a value into a object. This is useful in case another library might already parsed a JSON, or only a subpart of a JSON is supposed to be parsed. The usage of the function looks like that:

```dart
const json = '{}';
const parsedJson = jsonDecode(json);
const object = JsonMapper.fromParsedJson<TargetType>(parsedJson);
```