### PR TITLE
support deserialization of objects which reference their owning parent object (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,49 @@ class ProductCategory {
 }
 ```
 
+### Relative path reference to parent itself from nested object ".."
+
+In some cases objects need to interact with their (owning) parent object. The easiest pattern is to
+add a referencing field for the parent which is initialized during construction of the child object. 
+The path notation ".." to supports this pattern:
+
+```dart
+@jsonSerializable
+class Parent {
+  String? lastName;
+  List<Child> children = [];
+}
+
+@jsonSerializable
+class Child {
+  String? firstName;
+
+  Child(this.parent);
+
+  @JsonProperty(name: '..', ignoreForSerialization: true)
+  Parent parent;
+
+  @jsonConstructor
+  Child.json(this.parent);
+
+  @override
+  String get name =>
+    '$firstName ${parent.lastName}'.trim();
+}
+```
+
+You are now able to deserialize the following structure:
+
+```json
+{
+  "lastName": "Doe",
+  "children": [
+    {"firstName": "Eve"},
+    {"firstName": "Bob"},
+    {"firstName": "Alice"}
+]}
+```
+
 ## Name aliases configuration
 
 For cases when aliasing technique is desired, it's possible to optionally merge / route *many* json properties

--- a/mapper/lib/src/mapper.dart
+++ b/mapper/lib/src/mapper.dart
@@ -611,16 +611,18 @@ class JsonMapper {
       final jsonName = property.name;
       var value = property.value;
 
-      value = _deserializeObject(
-          value,
-          DeserializationContext(context.options,
-              typeInfo: paramTypeInfo,
-              jsonPropertyMeta: meta,
-              parentJsonMaps: <JsonMap>[
-                ...(context.parentJsonMaps ?? []),
-                jsonMap
-              ],
-              classMeta: context.classMeta));
+      if (property.name != '..') {
+        value = _deserializeObject(
+            value,
+            DeserializationContext(context.options,
+                typeInfo: paramTypeInfo,
+                jsonPropertyMeta: meta,
+                parentJsonMaps: <JsonMap>[
+                  ...(context.parentJsonMaps ?? []),
+                  jsonMap
+                ],
+                classMeta: context.classMeta));
+      }
       visitor(param, name, jsonName, classMeta, meta, value, paramTypeInfo);
     }
   }
@@ -868,6 +870,10 @@ class JsonMapper {
                     .constructorName,
                 positionalArguments,
                 namedArguments));
+
+    // Make [objectInstance] accessible for child objects
+    jsonMap.objectInstance = objectInstance;
+
     final im = _safeGetInstanceMirror(objectInstance)!;
     final inheritedPublicFieldNames = classInfo.inheritedPublicFieldNames;
     final mappedFields = namedArguments.keys


### PR DESCRIPTION
### Relative path reference to parent itself from nested object ".."

In reaction to enhancement #144:

In some cases objects need to interact with their (owning) parent object. The easiest pattern is to
add a referencing field for the parent which is initialized during construction of the child object. 
The path notation ".." supports this pattern:

```dart
@jsonSerializable
class Parent {
  String? lastName;
  List<Child> children = [];
}
@jsonSerializable
class Child {
  String? firstName;
  Child(this.parent);
  @JsonProperty(name: '..', ignoreForSerialization: true)
  Parent parent;
  @jsonConstructor
  Child.json(this.parent);
  @override
  String get name =>
    '$firstName ${parent.lastName}'.trim();
}
```

You are now able to deserialize the following structure:

```json
{
  "lastName": "Doe",
  "children": [
    {"firstName": "Eve"},
    {"firstName": "Bob"},
    {"firstName": "Alice"}
]}
```

All tests are running successfully. As this has been a manual rebase, please recheck integration  and test other adapters.

Best regards
Markus