### PR TITLE
support value injection in deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,7 +891,39 @@ You are now able to deserialize the following structure:
 ```
 
 and each `Child` object will have a reference on it's parent. And this parent field will not leak out
-to the serialized JSON object
+to the serialized JSON object.
+
+## Value injection
+
+Sometimes you have to *inject* certain values outside of a JSON object into the deserialization process.
+Using the [injectable] field, one may do so.
+
+```dart
+class Outside {}
+
+@jsonSerializable
+class Inside {
+  String? foo;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  Outside? outside;
+}
+```
+
+You may then inject the values in the [.deserialization] method:
+
+```json
+{
+  "foo": "Bar"
+}
+```
+
+```dart
+Outside outsideInstance = Outside();
+final insideInstance = JsonMapper.deserialize<Inside>(json, defaultDeserializationOptions, {'outside': outsideInstance})!;
+```
+
+Injection is currently limited to the root JSON object, without support for nested injection.
 
 ## Name aliases configuration
 

--- a/mapper/lib/src/model/annotations.dart
+++ b/mapper/lib/src/model/annotations.dart
@@ -173,6 +173,9 @@ class JsonProperty {
   /// Final field default value
   final dynamic defaultValue;
 
+  /// Declares annotated field as injectable by mapped value from [InjectableValues]
+  final bool? injectable;
+
   const JsonProperty(
       {this.scheme,
       this.name,
@@ -187,7 +190,8 @@ class JsonProperty {
       this.ignoreIfNull,
       this.converter,
       this.defaultValue,
-      this.converterParams});
+      this.converterParams,
+      this.injectable});
 
   static bool isRequired(JsonProperty? jsonProperty) =>
       jsonProperty != null &&

--- a/mapper/lib/src/model/index.dart
+++ b/mapper/lib/src/model/index.dart
@@ -82,6 +82,8 @@ class SerializationOptions extends DeserializationOptions {
             processAnnotatedMembersOnly: processAnnotatedMembersOnly);
 }
 
+typedef InjectableValues = Map<String, dynamic>;
+
 /// Describes a set of data / state to be re-used down the road of recursive
 /// process of Deserialization/Serialization
 class DeserializationContext {

--- a/mapper/test/test.constructors.dart
+++ b/mapper/test/test.constructors.dart
@@ -274,6 +274,58 @@ class Child3 {
   Parent3? parent;
 }
 
+class ParentInjected1 {
+  String? lastName;
+  List<ChildInjected1> children = [];
+}
+
+@jsonSerializable
+class ChildInjected1 {
+  String? firstName;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  ParentInjected1? parent;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  String? nickname;
+}
+
+class ParentInjected2 {
+  String? lastName;
+  List<ChildInjected2> children = [];
+}
+
+@jsonSerializable
+class ChildInjected2 {
+  String? firstName;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  ParentInjected2? parent;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  String? nickname;
+
+  ChildInjected2(this.parent);
+}
+
+class ParentInjected3 {
+  String? lastName;
+  List<ChildInjected3> children = [];
+}
+
+@jsonSerializable
+class ChildInjected3 {
+  String? firstName;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  ParentInjected3? parent;
+
+  @JsonProperty(ignoreForSerialization: true, injectable: true)
+  String? nickname;
+
+  ChildInjected3(this.parent);
+}
+
 void testConstructors() {
   group('[Verify class constructors support]', () {
     final json = '{"firstName":"Bob","lastName":"Marley"}';
@@ -562,6 +614,54 @@ void testConstructors() {
       expect(instance3.children[0].parent, instance3);
       expect(instance3.children[1].parent, instance3);
       expect(instance3.children[2].parent, instance3);
+    });
+
+    test('Referencing to injected object', () {
+      // given
+      final json1 = '''{
+    "firstName": "Alice"
+}''';
+
+      final json2 = '''{
+    "firstName": "Bob"
+}''';
+
+      final json3 = '''{
+    "firstName": "Eve"
+}''';
+      // when
+
+      ParentInjected1 parentInstance1 = ParentInjected1()..lastName =  "Doe";
+      final childInstance1 = JsonMapper.deserialize<ChildInjected1>(json1, defaultDeserializationOptions,
+          {'parent': parentInstance1,  'nickname': "Ally"})!;
+      parentInstance1.children.add(childInstance1);
+
+      ParentInjected2 parentInstance2 = ParentInjected2()..lastName =  "Doe";
+      final childInstance2 = JsonMapper.deserialize<ChildInjected2>(
+          json2, defaultDeserializationOptions,
+          {'parent': parentInstance2, 'nickname': "Bobby"})!;
+      parentInstance2.children.add(childInstance2);
+
+      ParentInjected3 parentInstance3 = ParentInjected3()..lastName =  "Doe";
+      final childInstance3 = JsonMapper.deserialize<ChildInjected3>(json3, defaultDeserializationOptions,
+          {'parent': parentInstance3})!;
+      parentInstance3.children.add(childInstance3);
+
+      // then
+      expect(parentInstance1.lastName, "Doe");
+      expect(childInstance1.parent, parentInstance1);
+      expect(childInstance1.firstName, "Alice");
+      expect(childInstance1.nickname, "Ally");
+
+      expect(parentInstance2.lastName, "Doe");
+      expect(childInstance2.parent, parentInstance2);
+      expect(childInstance2.firstName, "Bob");
+      expect(childInstance2.nickname, "Bobby");
+
+      expect(parentInstance3.lastName, "Doe");
+      expect(childInstance3.parent, parentInstance3);
+      expect(childInstance3.firstName, "Eve");
+      expect(childInstance3.nickname, null);
     });
   });
 }


### PR DESCRIPTION
# Value injection

Sometimes you have to *inject* certain values outside of a JSON object into the deserialization process.
Using the *injectable* field, one may do so.

```dart
class Outside {}
@jsonSerializable
class Inside {
  String? foo;

  @JsonProperty(ignoreForSerialization: true, injectable: true)
  Outside? outside;
}
```

You may then inject the values in the [.deserialization] method:

```json
{
  "foo": "Bar"
}
```

```dart
Outside outsideInstance = Outside();
final insideInstance = JsonMapper.deserialize<Inside>(json, defaultDeserializationOptions, {'outside': outsideInstance})!;
```

Injection is currently limited to the root JSON object, without support for nested injection.