### PR TITLE
Multiple fixes for complex structures.

### DIFF
--- a/adapters/built/lib/dart_json_mapper_built.dart
+++ b/adapters/built/lib/dart_json_mapper_built.dart
@@ -70,19 +70,19 @@ class BuiltMapConverter implements ICustomConverter, IRecursiveConverter {
   late DeserializeObjectFunction _deserializeObject;
 
   @override
-  dynamic fromJSON(dynamic jsonValue, [DeserializationContext? context]) {
+  dynamic fromJSON(dynamic jsonValue, DeserializationContext context) {
     if (context!.typeInfo != null && jsonValue is Map) {
       return jsonValue.map((key, value) => MapEntry(
-          _deserializeObject(key, context.typeInfo!.parameters.first),
-          _deserializeObject(value, context.typeInfo!.parameters.last)));
+          _deserializeObject(key, context, context.typeInfo!.parameters.first),
+          _deserializeObject(value, context, context.typeInfo!.parameters.last)));
     }
     return jsonValue;
   }
 
   @override
-  dynamic toJSON(dynamic object, [SerializationContext? context]) =>
+  dynamic toJSON(dynamic object, SerializationContext context) =>
       (object as BuiltMap).toMap().map((key, value) =>
-          MapEntry(_serializeObject(key).toString(), _serializeObject(value)));
+          MapEntry(_serializeObject(key, context).toString(), _serializeObject(value, context)));
 
   @override
   void setSerializeObjectFunction(SerializeObjectFunction serializeObject) {

--- a/mapper/lib/src/mapper.dart
+++ b/mapper/lib/src/mapper.dart
@@ -745,9 +745,8 @@ class JsonMapper {
     }
     if (converter is IRecursiveConverter) {
       (converter as IRecursiveConverter).setSerializeObjectFunction(
-          (o) => _serializeObject(o, context as SerializationContext));
-      (converter as IRecursiveConverter).setDeserializeObjectFunction((o,
-              type) =>
+          (o, context) => _serializeObject(o, context as SerializationContext));
+      (converter as IRecursiveConverter).setDeserializeObjectFunction((o, context, type) =>
           _deserializeObject(o, context.reBuild(typeInfo: _getTypeInfo(type))));
     }
   }


### PR DESCRIPTION
Dear @k-paxian

I hope you are well 😁 I am currently finishing a quite complex MobX.dart serialization project with multiple nested levels of stores, inheritance, embedded Protobuf JSON, and so on. `dart-json-mapper` is quite stable, but some important problems occured to me on the last mile (especially regarding the relative parent references).

There are bugs present, which prevent a complex structure from

* Getting serialized multiple times and outputing up to date values (`_convertedValuesCache` is not cleared on serialization)
* Referencing non-existent parent in context in `_resolveProperty` during serialization (Exception) altough field is and should be ignored later on
* Correctly deserializing a root-object with a list of sub-objects with relative parent references to the root object, each of the sub-objects with a list of sub-sub-objects each also referencing their parent sub-object relatively, due to `_deserializeObject` not using or being reset to correct `DeserializationContext` on iteration from last sub-sub-object in list to sub-object. Converters are wrongly assuming deepest state due to using the same `DefaultIterableConverter` instance.


I hope this finds you well, and would be delighted if you could find some time in the future to check and migrate my suggestions for the bug fixes.

Best regards
Markus

